### PR TITLE
Update kovan zAuction address for configuration

### DIFF
--- a/src/actions/helpers/index.ts
+++ b/src/actions/helpers/index.ts
@@ -3,21 +3,21 @@ import { Registrar } from "../../contracts/types";
 export const validateUserOwnsDomain = async (
   domainId: string,
   potentialOwner: string,
-  registrar: Registrar,
-  message: string
+  registrar: Registrar
 ) => {
   const owner = await registrar.ownerOf(domainId);
-  if (potentialOwner !== owner) throw Error(message);
+  if (potentialOwner !== owner)
+    throw Error("Must own domain to modify");
 };
 
 export const validateStatus = async (
   domainId: string,
   registrar: Registrar,
-  lockStatus: boolean,
-  message: string
+  lockStatus: boolean
 ) => {
   const record = await registrar.records(domainId);
-  if (record.metadataLocked === lockStatus) throw Error(message);
+  if (record.metadataLocked === lockStatus)
+    throw Error("Metadata must be unlocked to be modified");
 };
 
 export const validateOwnerAndStatus = async (
@@ -25,19 +25,7 @@ export const validateOwnerAndStatus = async (
   registrar: Registrar,
   potentialOwner: string,
   lockStatus: boolean,
-  ownerMessage: string,
-  statusMessage: string
 ) => {
-  validateUserOwnsDomain(
-    domainId,
-    potentialOwner,
-    registrar,
-    ownerMessage
-  );
-  validateStatus(
-    domainId,
-    registrar,
-    lockStatus,
-    statusMessage
-  );
-}
+  validateUserOwnsDomain(domainId, potentialOwner, registrar);
+  validateStatus(domainId, registrar, lockStatus);
+};

--- a/src/actions/lockDomainMetadata.ts
+++ b/src/actions/lockDomainMetadata.ts
@@ -1,29 +1,20 @@
 import { ethers } from "ethers";
 import { Registrar } from "../contracts/types";
-import { validateUserOwnsDomain, validateStatus } from "./helpers";
+import { validateOwnerAndStatus } from "./helpers";
 
 // Call to set domain metadata lock status to `lockStatus`
 // e.g. set to `true` to lock, and `false` to unlock
 export const lockDomainMetadata = async (
   domainId: string,
   lockStatus: boolean,
+  signer: ethers.Signer,
   registrar: Registrar
 ): Promise<ethers.ContractTransaction> => {
-  const potentialOwner = await registrar.signer.getAddress();
-  validateUserOwnsDomain(
-    domainId,
-    potentialOwner,
-    registrar,
-    "Must own domain to lock metadata"
-  );
+  const signerAddress = await signer.getAddress();
+
   // Will throw an error if the lock status from the registrar is the same as the given lock.
   // e.g. You cannot lock already locked domain metadata, and you cannot unlock already unlocked domain metadata.
-  validateStatus(
-    domainId,
-    registrar,
-    lockStatus,
-    "Metadata lock is already set to given lock status"
-  );
+  validateOwnerAndStatus(domainId, registrar, signerAddress, lockStatus);
 
   const tx = await registrar.lockDomainMetadata(domainId, lockStatus);
   return tx;

--- a/src/actions/setAndLockDomainMetadata.ts
+++ b/src/actions/setAndLockDomainMetadata.ts
@@ -8,25 +8,17 @@ export const setAndLockDomainMetadata = async (
   domainId: string,
   metadata: DomainMetadata,
   client: ApiClient,
-  potentialOwner: ethers.Signer,
+  signer: ethers.Signer,
   registrar: Registrar
 ): Promise<ethers.ContractTransaction> => {
   const isLocked = true;
-  const ownerMessage = "Must own domain to update metadata";
-  const statusMessage = "Metadata must be unlocked to be modified"
-  const potentialOwnerAddress = await potentialOwner.getAddress();
+  const signerAddress = await signer.getAddress();
 
-  validateOwnerAndStatus(
-    domainId,
-    registrar,
-    potentialOwnerAddress,
-    isLocked,
-    ownerMessage,
-    statusMessage
-  );
+  validateOwnerAndStatus(domainId, registrar, signerAddress, isLocked);
   const metadataUri = await client.uploadMetadata(metadata);
 
-  const tx = await registrar.connect(potentialOwner)
+  const tx = await registrar
+    .connect(signer)
     .setAndLockDomainMetadata(domainId, metadataUri);
   return tx;
 };

--- a/src/actions/setAndLockDomainMetadataUri.ts
+++ b/src/actions/setAndLockDomainMetadataUri.ts
@@ -5,23 +5,13 @@ import { validateOwnerAndStatus } from "./helpers";
 export const setAndLockDomainMetadataUri = async (
   domainId: string,
   metadataUri: string,
-  potentialOwner: ethers.Signer,
+  signer: ethers.Signer,
   registrar: Registrar
 ): Promise<ethers.ContractTransaction> => {
   const isLocked = true;
-  const ownerMessage = "Must own domain to update metadata";
-  const statusMessage = "Metadata must be unlocked to be modified";
-  const potentialOwnerAddress = await potentialOwner.getAddress();
+  const signerAddress = await signer.getAddress();
 
-
-  validateOwnerAndStatus(
-    domainId,
-    registrar,
-    potentialOwnerAddress,
-    isLocked,
-    ownerMessage,
-    statusMessage
-  );
+  validateOwnerAndStatus(domainId, registrar, signerAddress, isLocked);
 
   const tx = await registrar.setAndLockDomainMetadata(domainId, metadataUri);
   return tx;

--- a/src/actions/setDomainMetadata.ts
+++ b/src/actions/setDomainMetadata.ts
@@ -8,25 +8,17 @@ export const setDomainMetadata = async (
   domainId: string,
   metadata: DomainMetadata,
   client: ApiClient,
-  potentialOwner: ethers.Signer,
+  signer: ethers.Signer,
   registrar: Registrar
 ): Promise<ethers.ContractTransaction> => {
   const isLocked = true;
-  const ownerMessage = "Must own domain to update metadata";
-  const statusMessage = "Metadata must be unlocked to be modified"
-  const potentialOwnerAddress = await potentialOwner.getAddress();
+  const signerAddress = await signer.getAddress();
 
-  validateOwnerAndStatus(
-    domainId,
-    registrar,
-    potentialOwnerAddress,
-    isLocked,
-    ownerMessage,
-    statusMessage
-  );
+  validateOwnerAndStatus(domainId, registrar, signerAddress, isLocked);
 
   const metadataUri = await client.uploadMetadata(metadata);
-  const tx = await registrar.connect(potentialOwner)
+  const tx = await registrar
+    .connect(signer)
     .setDomainMetadataUri(domainId, metadataUri);
   return tx;
-}
+};

--- a/src/actions/setDomainMetadataUri.ts
+++ b/src/actions/setDomainMetadataUri.ts
@@ -5,23 +5,14 @@ import { ethers } from "ethers";
 export const setDomainMetadataUri = async (
   domainId: string,
   metadataUri: string,
-  potentialOwner: ethers.Signer,
+  signer: ethers.Signer,
   registrar: Registrar
 ): Promise<ethers.ContractTransaction> => {
   const isLocked = true;
-  const ownerMessage = "Must own domain to update metadata";
-  const statusMessage = "Metadata must be unlocked to be modified";
-  const potentialOwnerAddress = await potentialOwner.getAddress();
+  const signerAddress = await signer.getAddress();
 
-  validateOwnerAndStatus(
-    domainId,
-    registrar,
-    potentialOwnerAddress,
-    isLocked,
-    ownerMessage,
-    statusMessage
-  )
+  validateOwnerAndStatus(domainId, registrar, signerAddress, isLocked);
 
   const tx = await registrar.setDomainMetadataUri(domainId, metadataUri);
   return tx;
-}
+};

--- a/src/actions/setDomainRoyalty.ts
+++ b/src/actions/setDomainRoyalty.ts
@@ -5,15 +5,12 @@ import { validateUserOwnsDomain } from "./helpers";
 export const setDomainRoyalty = async (
   domainId: string,
   amount: ethers.BigNumber,
+  signer: ethers.Signer,
   registrar: Registrar
 ): Promise<ethers.ContractTransaction> => {
-  const potentialOwner = await registrar.signer.getAddress();
-  validateUserOwnsDomain(
-    domainId,
-    potentialOwner,
-    registrar,
-    "Can only change the royalty on a domain you own"
-  );
+  const signerAddress = await signer.getAddress();
+
+  validateUserOwnsDomain(domainId, signerAddress, registrar);
 
   const tx = await registrar.setDomainRoyaltyAmount(domainId, amount);
   return tx;

--- a/src/api/actions/uploadMetadata.ts
+++ b/src/api/actions/uploadMetadata.ts
@@ -18,6 +18,6 @@ export const uploadMetadata = async (
     throw Error(`Failed to upload metadata: ${e}`);
   }
 
-  const url = response.url;
+  const url = ipfsHashToUrl(response.hash);
   return url;
 };

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -2,7 +2,7 @@ import { ethers } from "ethers";
 import * as zAuction from "@zero-tech/zauction-sdk";
 
 export const zAuctionConfiguration = (
-  web3Provider: ethers.providers.Web3Provider,
+  web3Provider: ethers.providers.Provider,
   network: string,
   apiUri?: string,
   subgraphUri?: string,
@@ -24,7 +24,7 @@ export const zAuctionConfiguration = (
     defaultApiUri = "https://zauction-kovan-api.herokuapp.com/api";
     defaultSubgraphUri =
       "https://api.thegraph.com/subgraphs/name/zer0-os/zauction-kovan";
-    defaultZAuctionAddress = "0x18A804a028aAf1F30082E91d2947734961Dd7f89";
+    defaultZAuctionAddress = "0x646757a5F3C9eEB4C6Bd136fCefE655B4A8107e4";
     defaultTokenContract = "0xC613fCc3f81cC2888C5Cccc1620212420FFe4931";
   } else {
     throw Error(`Network ${network} is not supported`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,7 @@ export const createInstance = (config: Config): Instance => {
       const tx = await actions.lockDomainMetadata(
         domainId,
         lockStatus,
+        signer,
         registrar
       );
 
@@ -132,7 +133,11 @@ export const createInstance = (config: Config): Instance => {
       signer: ethers.Signer
     ): Promise<DomainMetadata> => {
       const registrar: Registrar = await getRegistrar(signer, config.registrar);
-      const metadata = await actions.getDomainMetadata(domainId, registrar, IPFSGatewayUri.fleek);
+      const metadata = await actions.getDomainMetadata(
+        domainId,
+        registrar,
+        IPFSGatewayUri.fleek
+      );
       return metadata;
     },
     getDomainMetadataUri: async (
@@ -210,7 +215,12 @@ export const createInstance = (config: Config): Instance => {
     ): Promise<ethers.ContractTransaction> => {
       const registrar: Registrar = await getRegistrar(signer, config.registrar);
 
-      const tx = await actions.setDomainRoyalty(domainId, amount, registrar);
+      const tx = await actions.setDomainRoyalty(
+        domainId,
+        amount,
+        signer,
+        registrar
+      );
       return tx;
     },
     zauction: {
@@ -289,8 +299,7 @@ export const createInstance = (config: Config): Instance => {
           cancelOnChain,
           signer
         );
-        if (tx)
-          return tx;
+        if (tx) return tx;
       },
 
       needsToApproveZAuctionToTransferNfts: async (
@@ -365,10 +374,13 @@ export const createInstance = (config: Config): Instance => {
           domainIdToDomainName
         );
         const domain = await subgraphClient.getDomainById(tokenId);
-        const listing: Listing = await zAuctionInstance.getBuyNowPrice(tokenId, signer);
+        const listing: Listing = await zAuctionInstance.getBuyNowPrice(
+          tokenId,
+          signer
+        );
         if (listing.holder.toLowerCase() !== domain.owner.toLowerCase())
           return 0;
-        return listing.price
+        return listing.price;
       },
       setBuyNowPrice: async (
         params: zAuction.BuyNowParams,
@@ -412,7 +424,7 @@ export const createInstance = (config: Config): Instance => {
           throw new Error(invalidInputMessage);
         }
         if (urls.length == 0) {
-          return new Promise<UrlToJobId>(() => { });
+          return new Promise<UrlToJobId>(() => {});
         }
         return apiClient.startBulkUpload(urls);
       },
@@ -422,7 +434,7 @@ export const createInstance = (config: Config): Instance => {
           throw new Error(invalidInputMessage);
         }
         if (jobIds.length == 0) {
-          return new Promise<UploadJobStatus>(() => { });
+          return new Promise<UploadJobStatus>(() => {});
         }
         return apiClient.checkBulkUploadJob(jobIds);
       },

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -7,7 +7,13 @@ import * as zAuction from "@zero-tech/zauction-sdk";
 import * as subgraph from "../src/subgraph";
 
 import * as actions from "../src/actions";
-import { Config, DomainMetadata, IPFSGatewayUri, Listing, zAuctionRoute } from "../src/types";
+import {
+  Config,
+  DomainMetadata,
+  IPFSGatewayUri,
+  Listing,
+  zAuctionRoute,
+} from "../src/types";
 import { Registrar } from "../src/contracts/types";
 import { getRegistrar } from "../src/contracts";
 import { createClient } from "../src/api";
@@ -35,7 +41,6 @@ describe("Test Custom SDK Logic", () => {
   const legacyZAuctionAddress = "0x18A804a028aAf1F30082E91d2947734961Dd7f89";
   const newZAuctionAddress = "0x646757a5F3C9eEB4C6Bd136fCefE655B4A8107e4";
   const registrarAddress = "0xC613fCc3f81cC2888C5Cccc1620212420FFe4931";
-
 
   // Kovan config
   const config: Config = {

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -2,47 +2,102 @@ import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 import * as ethers from "ethers";
 import * as dotenv from "dotenv";
+import * as zAuction from "@zero-tech/zauction-sdk";
+
+import * as subgraph from "../src/subgraph";
 
 import * as actions from "../src/actions";
-import { DomainMetadata, IPFSGatewayUri } from "../src/types";
+import { Config, DomainMetadata, IPFSGatewayUri, Listing, zAuctionRoute } from "../src/types";
 import { Registrar } from "../src/contracts/types";
 import { getRegistrar } from "../src/contracts";
-import { createClient } from "../src/api"
+import { createClient } from "../src/api";
+import {
+  createZAuctionInstances,
+  getZAuctionInstanceForDomain,
+} from "../src/utilities";
+import { zAuctionConfiguration } from "../src/configuration/configuration";
 
 chai.use(chaiAsPromised.default);
 const expect = chai.expect;
 dotenv.config();
 
 describe("Test Custom SDK Logic", () => {
-  const provider = new ethers.providers.JsonRpcProvider(process.env["INFURA_URL"], 42)
-
-  // Kovan registrar address
-  const registrarAddress = "0xC613fCc3f81cC2888C5Cccc1620212420FFe4931";
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env["INFURA_URL"],
+    42
+  );
 
   const pk = process.env["PRIVATE_KEY"];
   if (!pk) throw Error("No private key");
   const signer = new ethers.Wallet(pk, provider);
 
+  // Kovan zAuction
+  const legacyZAuctionAddress = "0x18A804a028aAf1F30082E91d2947734961Dd7f89";
+  const newZAuctionAddress = "0x646757a5F3C9eEB4C6Bd136fCefE655B4A8107e4";
+  const registrarAddress = "0xC613fCc3f81cC2888C5Cccc1620212420FFe4931";
+
+
+  // Kovan config
+  const config: Config = {
+    subgraphUri: "https://api.thegraph.com/subgraphs/name/zer0-os/zns-kovan",
+    apiUri: "https://zns.api.zero.tech/api",
+    metricsUri: "https://zns-metrics-kovan.herokuapp.com",
+    zAuctionRoutes: [
+      {
+        uriPattern: "wilder",
+        // Use default values
+        config: zAuctionConfiguration(
+          provider,
+          "kovan",
+          undefined,
+          undefined,
+          newZAuctionAddress // override existing zAuction address
+        ) as zAuction.Config,
+      } as zAuctionRoute,
+    ],
+    basicController: "0x2EF34C52138781C901Fe9e50B64d80aA9903f730",
+    registrar: "0xC613fCc3f81cC2888C5Cccc1620212420FFe4931",
+  };
+
   // Random wheels metadata qm hash
   const qmHash = "QmYTYkmSPGh4NLDMVtKcDTADnVD8HiCTVQKHMKNKQXD67n";
+  const kovanDomainId =
+    "0x7080e65e58e5fa0e2bacb7c947a817ef6d96832680d2c54e1373109380c121e1";
+
+  const subgraphClient = subgraph.createClient(config.subgraphUri);
+
+  const domainIdToDomainName = async (domainId: string) => {
+    const domainData = await subgraphClient.getDomainById(domainId);
+    return domainData.name;
+  };
 
   describe("getDomainMetadata", () => {
     it("runs as ipfs url", async () => {
       const mockRegistrar = {
-        tokenURI: () => { return `ipfs://${qmHash}` }
+        tokenURI: () => {
+          return `ipfs://${qmHash}`;
+        },
       } as unknown as Registrar;
-
-      const metadata = await actions.getDomainMetadata("0x1", mockRegistrar, IPFSGatewayUri.fleek);
+      const metadata = await actions.getDomainMetadata(
+        "0x1",
+        mockRegistrar,
+        IPFSGatewayUri.fleek
+      );
       expect(metadata);
     });
     it("runs as well formed ipfs.fleek.co url", async () => {
       const mockRegistrar = {
-        tokenURI: () => { return `https://ipfs.fleek.co/ipfs/${qmHash}` }
+        tokenURI: () => {
+          return `https://ipfs.fleek.co/ipfs/${qmHash}`;
+        },
       } as unknown as Registrar;
-
-      const metadata = await actions.getDomainMetadata("0x1", mockRegistrar, IPFSGatewayUri.fleek);
+      const metadata = await actions.getDomainMetadata(
+        "0x1",
+        mockRegistrar,
+        IPFSGatewayUri.fleek
+      );
       expect(metadata);
-    })
+    });
   });
   describe("setDomainMetadata", () => {
     it("runs setdomainMetadata", async () => {
@@ -58,29 +113,44 @@ describe("Test Custom SDK Logic", () => {
         customDomainHeader: false,
         previewImage: "preview_image",
         customDomainHeaderValue: "custom_domain",
-      }
-
-      const registrar: Registrar = await getRegistrar(provider, registrarAddress);
+      };
+      const registrar: Registrar = await getRegistrar(
+        provider,
+        registrarAddress
+      );
       const apiUri = "https://zns.api.zero.tech/api";
       const client = createClient(apiUri);
-
-      const kovanDomain = "0x7080e65e58e5fa0e2bacb7c947a817ef6d96832680d2c54e1373109380c121e1"
-
       const tx = await actions.setDomainMetadata(
-        kovanDomain,
+        kovanDomainId,
         metadata,
         client,
         signer,
         registrar
       );
       console.log(tx);
-
       const retrievedMetadata = await actions.getDomainMetadata(
-        kovanDomain,
+        kovanDomainId,
         registrar,
         IPFSGatewayUri.fleek
       );
       expect(metadata).deep.equal(retrievedMetadata);
+    });
+  });
+  describe("getBuyNowPrice", () => {
+    it("runs as expected", async () => {
+      const zAuctionRouteUriToInstance = createZAuctionInstances(config);
+
+      const zAuctionInstance = await getZAuctionInstanceForDomain(
+        kovanDomainId,
+        config.zAuctionRoutes,
+        zAuctionRouteUriToInstance,
+        domainIdToDomainName
+      );
+      const listing: Listing = await zAuctionInstance.getBuyNowPrice(
+        kovanDomainId,
+        signer
+      );
+      console.log(listing);
     });
   });
 });


### PR DESCRIPTION
This needs to be updated so the dApp team can test `getBuyNowPrice` and similar functions that don't exist on the legacy zauction contract.

intentionally branched from the other `bugFix` branch I was working on to be sure I can have both fixes running in tests simultaneously 