### PR TITLE
Fixed getAllDomains query

### DIFF
--- a/src/subgraph/actions/getAllDomains.ts
+++ b/src/subgraph/actions/getAllDomains.ts
@@ -16,7 +16,7 @@ export const getAllDomains = async <T>(
     const queryResult = await performQuery<DomainsQueryDto>(
       apolloClient,
       queries.getAllDomains,
-      { count: queryCount, skipAmount: skip }
+      { count: queryCount, startIndex: skip }
     );
 
     const queriedDomains = queryResult.data.domains;

--- a/src/subgraph/queries.ts
+++ b/src/subgraph/queries.ts
@@ -110,8 +110,12 @@ export const getDomainMintEvent = gql`
 `;
 
 export const getAllDomains = gql`
-  query Domains($count: Int!, $skipAmount: Int!) {
-    domains(first: $count, skip: $skipAmount) {
+  query Domains($count: Int!, $startIndex: Int!) {
+    domains(
+      first: $count
+      where: { indexId_gt: $startIndex }
+      orderBy: indexId
+    ) {
       id
       name
       parent {


### PR DESCRIPTION
The getAllDomains query was failing due to subgraph limitations. This has been patched with a new `indexId` mechanism where each domain that gets minted has a unique `indexId` which starts at 1 for the first domain, and increments every time a domain is minted. This allows for pagination when querying all domains.