### PR TITLE
Map allowance and approval requests to proper registrar contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/sinon": "10.0.2",
     "@typescript-eslint/eslint-plugin": "4.31.0",
     "@typescript-eslint/parser": "4.31.0",
-    "@zero-tech/zauction-sdk": "0.0.50",
+    "@zero-tech/zauction-sdk": "0.0.51",
     "chai": "4.3.4",
     "chai-as-promised": "7.1.1",
     "dotenv": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/sinon": "10.0.2",
     "@typescript-eslint/eslint-plugin": "4.31.0",
     "@typescript-eslint/parser": "4.31.0",
-    "@zero-tech/zauction-sdk": "0.0.42",
+    "@zero-tech/zauction-sdk": "0.0.50",
     "chai": "4.3.4",
     "chai-as-promised": "7.1.1",
     "dotenv": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/sinon": "10.0.2",
     "@typescript-eslint/eslint-plugin": "4.31.0",
     "@typescript-eslint/parser": "4.31.0",
-    "@zero-tech/zauction-sdk": "0.0.51",
+    "@zero-tech/zauction-sdk": "0.0.55",
     "chai": "4.3.4",
     "chai-as-promised": "7.1.1",
     "dotenv": "10.0.0",
@@ -53,7 +53,7 @@
     "lolex": "6.0.0"
   },
   "peerDependencies": {
-    "@zero-tech/zauction-sdk": ">=0.0.42",
+    "@zero-tech/zauction-sdk": ">=0.0.55",
     "ethers": "^5.4.6"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,8 @@ export const createInstance = (config: Config): Instance => {
       needsToApproveZAuctionToSpendTokens: async (
         domainId: string,
         account: string,
+        bid: Bid,
+        signer: ethers.Signer,
         bidAmount: ethers.BigNumber
       ): Promise<boolean> => {
         const zAuctionInstance = await getZAuctionInstanceForDomain(
@@ -228,15 +230,22 @@ export const createInstance = (config: Config): Instance => {
           domainIdToDomainName
         );
 
-        const allowance = await zAuctionInstance.getZAuctionSpendAllowance(
-          account
+        const hub: ZNSHub = await getHubContract(signer, config.hub);
+        const registrar: Registrar = await getRegistrarForDomain(hub, domainId);
+
+        const allowance = await zAuctionInstance.getZAuctionSpendAllowanceByBid(
+          account,
+          bid,
+          registrar
         );
         const isApproved = allowance.gte(bidAmount);
         return isApproved;
       },
+
       approveZAuctionToSpendTokens: async (
         domainId: string,
-        signer: ethers.Signer
+        signer: ethers.Signer,
+        bid: Bid
       ): Promise<ethers.ContractTransaction> => {
         const zAuctionInstance = await getZAuctionInstanceForDomain(
           domainId,
@@ -245,8 +254,9 @@ export const createInstance = (config: Config): Instance => {
           domainIdToDomainName
         );
 
-        const tx = await zAuctionInstance.approveZAuctionSpendTradeTokens(
-          signer
+        const tx = await zAuctionInstance.approveZAuctionSpendTradeTokensByBid(
+          signer,
+          bid
         );
 
         return tx;
@@ -308,7 +318,9 @@ export const createInstance = (config: Config): Instance => {
       },
       needsToApproveZAuctionToTransferNfts: async (
         domainId: string,
-        account: string
+        account: string,
+        signer: ethers.Signer,
+        bid: Bid
       ): Promise<boolean> => {
         const zAuctionInstance = await getZAuctionInstanceForDomain(
           domainId,
@@ -317,14 +329,23 @@ export const createInstance = (config: Config): Instance => {
           domainIdToDomainName
         );
 
+        const hub: ZNSHub = await getHubContract(signer, config.hub);
+        const registrar: Registrar = await getRegistrarForDomain(hub, domainId);
+
         const isApproved =
-          await zAuctionInstance.isZAuctionApprovedToTransferNft(account);
+          await zAuctionInstance.isZAuctionApprovedToTransferNftByBid(
+            account,
+            bid,
+            registrar
+          );
 
         return isApproved;
       },
+
       approveZAuctionToTransferNfts: async (
         domainId: string,
-        signer: ethers.Signer
+        signer: ethers.Signer,
+        bid: Bid
       ): Promise<ethers.ContractTransaction> => {
         const zAuctionInstance = await getZAuctionInstanceForDomain(
           domainId,
@@ -333,7 +354,13 @@ export const createInstance = (config: Config): Instance => {
           domainIdToDomainName
         );
 
-        const tx = await zAuctionInstance.approveZAuctionTransferNft(signer);
+        const hub: ZNSHub = await getHubContract(signer, config.hub);
+        const registrar: Registrar = await getRegistrarForDomain(hub, domainId);
+
+        const tx = await zAuctionInstance.approveZAuctionTransferNftByBid(
+          bid,
+          registrar
+        );
 
         return tx;
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,11 @@ export const createInstance = (config: Config): Instance => {
     return domainData.name;
   };
 
+  const getDomainContractForDomain = async (domainId: string) => {
+    const domain = await subgraphClient.getDomainById(domainId);
+    return domain.contract;
+  };
+
   const instance: Instance = {
     getDomainById: subgraphClient.getDomainById,
     getDomainsByName: subgraphClient.getDomainsByName,
@@ -56,7 +61,8 @@ export const createInstance = (config: Config): Instance => {
         domainId,
         config.zAuctionRoutes,
         zAuctionRouteUriToInstance,
-        domainIdToDomainName
+        domainIdToDomainName,
+        getDomainContractForDomain
       );
 
       return actions.getDomainEvents(domainId, {
@@ -71,7 +77,8 @@ export const createInstance = (config: Config): Instance => {
         domainId,
         config.zAuctionRoutes,
         zAuctionRouteUriToInstance,
-        domainIdToDomainName
+        domainIdToDomainName,
+        getDomainContractForDomain
       ),
     getAllDomains: subgraphClient.getAllDomains,
     getDomainMetrics: async (domainIds: string[]) =>
@@ -219,24 +226,18 @@ export const createInstance = (config: Config): Instance => {
       needsToApproveZAuctionToSpendTokens: async (
         domainId: string,
         account: string,
-        bid: Bid,
-        signer: ethers.Signer,
         bidAmount: ethers.BigNumber
       ): Promise<boolean> => {
         const zAuctionInstance = await getZAuctionInstanceForDomain(
           domainId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
 
-        const hub: ZNSHub = await getHubContract(signer, config.hub);
-        const registrar: Registrar = await getRegistrarForDomain(hub, domainId);
-
-        const allowance = await zAuctionInstance.getZAuctionSpendAllowanceByBid(
-          account,
-          bid,
-          registrar
+        const allowance = await zAuctionInstance.getZAuctionSpendAllowance(
+          account
         );
         const isApproved = allowance.gte(bidAmount);
         return isApproved;
@@ -244,23 +245,101 @@ export const createInstance = (config: Config): Instance => {
 
       approveZAuctionToSpendTokens: async (
         domainId: string,
-        signer: ethers.Signer,
-        bid: Bid
+        signer: ethers.Signer
       ): Promise<ethers.ContractTransaction> => {
         const zAuctionInstance = await getZAuctionInstanceForDomain(
           domainId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
 
-        const tx = await zAuctionInstance.approveZAuctionSpendTradeTokensByBid(
-          signer,
-          bid
+        const tx = await zAuctionInstance.approveZAuctionSpendTradeTokens(
+          signer
         );
 
         return tx;
       },
+
+      needsToApproveZAuctionToTransferNfts: async (
+        domainId: string,
+        account: string
+      ): Promise<boolean> => {
+        const zAuctionInstance = await getZAuctionInstanceForDomain(
+          domainId,
+          config.zAuctionRoutes,
+          zAuctionRouteUriToInstance,
+          domainIdToDomainName,
+          getDomainContractForDomain
+        );
+
+        const isApproved =
+          await zAuctionInstance.isZAuctionApprovedToTransferNft(account);
+
+        return isApproved;
+      },
+
+      needsToApproveZAuctionToTransferNftsByBid: async (
+        domainId: string,
+        account: string,
+        bid: Bid
+      ): Promise<boolean> => {
+        const zAuctionInstance = await getZAuctionInstanceForDomain(
+          domainId,
+          config.zAuctionRoutes,
+          zAuctionRouteUriToInstance,
+          domainIdToDomainName,
+          getDomainContractForDomain
+        );
+
+        const isApproved =
+          await zAuctionInstance.isZAuctionApprovedToTransferNftByBid(
+            account,
+            bid
+          );
+
+        return isApproved;
+      },
+
+      approveZAuctionToTransferNfts: async (
+        domainId: string,
+        signer: ethers.Signer
+      ): Promise<ethers.ContractTransaction> => {
+        const zAuctionInstance = await getZAuctionInstanceForDomain(
+          domainId,
+          config.zAuctionRoutes,
+          zAuctionRouteUriToInstance,
+          domainIdToDomainName,
+          getDomainContractForDomain
+        );
+
+        const tx = await zAuctionInstance.approveZAuctionTransferNft(signer);
+
+        return tx;
+      },
+
+      approveZAuctionToTransferNftsByBid: async (
+        domainId: string,
+        bid: Bid,
+        signer: ethers.Signer
+      ): Promise<ethers.ContractTransaction> => {
+        const zAuctionInstance = await getZAuctionInstanceForDomain(
+          domainId,
+          config.zAuctionRoutes,
+          zAuctionRouteUriToInstance,
+          domainIdToDomainName,
+          getDomainContractForDomain
+        );
+
+        const tx = await zAuctionInstance.approveZAuctionTransferNftByBid(
+          bid,
+          signer
+        );
+
+        return tx;
+      },
+
       placeBid: async (
         params: PlaceBidParams,
         signer: ethers.Signer
@@ -269,7 +348,8 @@ export const createInstance = (config: Config): Instance => {
           params.domainId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
 
         await zAuctionInstance.placeBid(
@@ -292,7 +372,8 @@ export const createInstance = (config: Config): Instance => {
           domainId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
 
         const tx = await zAuctionInstance.cancelBid(
@@ -303,12 +384,14 @@ export const createInstance = (config: Config): Instance => {
         );
         if (tx) return tx;
       },
+
       listBids: async (domainId: string) => {
         const zAuctionInstance = await getZAuctionInstanceForDomain(
           domainId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
 
         const bidCollection = await zAuctionInstance.listBids([domainId]);
@@ -316,54 +399,7 @@ export const createInstance = (config: Config): Instance => {
 
         return domainBids;
       },
-      needsToApproveZAuctionToTransferNfts: async (
-        domainId: string,
-        account: string,
-        signer: ethers.Signer,
-        bid: Bid
-      ): Promise<boolean> => {
-        const zAuctionInstance = await getZAuctionInstanceForDomain(
-          domainId,
-          config.zAuctionRoutes,
-          zAuctionRouteUriToInstance,
-          domainIdToDomainName
-        );
 
-        const hub: ZNSHub = await getHubContract(signer, config.hub);
-        const registrar: Registrar = await getRegistrarForDomain(hub, domainId);
-
-        const isApproved =
-          await zAuctionInstance.isZAuctionApprovedToTransferNftByBid(
-            account,
-            bid,
-            registrar
-          );
-
-        return isApproved;
-      },
-
-      approveZAuctionToTransferNfts: async (
-        domainId: string,
-        signer: ethers.Signer,
-        bid: Bid
-      ): Promise<ethers.ContractTransaction> => {
-        const zAuctionInstance = await getZAuctionInstanceForDomain(
-          domainId,
-          config.zAuctionRoutes,
-          zAuctionRouteUriToInstance,
-          domainIdToDomainName
-        );
-
-        const hub: ZNSHub = await getHubContract(signer, config.hub);
-        const registrar: Registrar = await getRegistrarForDomain(hub, domainId);
-
-        const tx = await zAuctionInstance.approveZAuctionTransferNftByBid(
-          bid,
-          registrar
-        );
-
-        return tx;
-      },
       acceptBid: async (
         bid: Bid,
         signer: ethers.Signer
@@ -372,7 +408,8 @@ export const createInstance = (config: Config): Instance => {
           bid.tokenId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
 
         const tx = await zAuctionInstance.acceptBid(bid, signer);
@@ -388,7 +425,8 @@ export const createInstance = (config: Config): Instance => {
           params.tokenId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
 
         const tx = await zAuctionInstance.buyNow(params, signer);
@@ -399,7 +437,8 @@ export const createInstance = (config: Config): Instance => {
           tokenId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
         const domain = await subgraphClient.getDomainById(tokenId);
         const listing: zAuction.Listing = await zAuctionInstance.getBuyNowPrice(
@@ -417,7 +456,8 @@ export const createInstance = (config: Config): Instance => {
           params.tokenId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
         const tx = await zAuctionInstance.setBuyNowPrice(params, signer);
         return tx;
@@ -430,7 +470,8 @@ export const createInstance = (config: Config): Instance => {
           tokenId,
           config.zAuctionRoutes,
           zAuctionRouteUriToInstance,
-          domainIdToDomainName
+          domainIdToDomainName,
+          getDomainContractForDomain
         );
 
         const tx = await zAuctionInstance.cancelBuyNow(tokenId, signer);

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,6 +208,8 @@ export interface Instance {
     needsToApproveZAuctionToSpendTokens(
       domainId: string,
       account: string,
+      bid: Bid,
+      signer: ethers.Signer,
       bidAmount: ethers.BigNumber
     ): Promise<boolean>;
 
@@ -218,7 +220,33 @@ export interface Instance {
      */
     approveZAuctionToSpendTokens(
       domainId: string,
-      signer: ethers.Signer
+      signer: ethers.Signer,
+      bid: Bid
+    ): Promise<ethers.ContractTransaction>;
+
+    /**
+     * Checks whether a user has approved zAuction to transfer NFT's on their behalf.
+     * zAuction must be approved before a user can accept a bid for a domain they own.
+     * @param domainId The domain ID that is going to be sold
+     * @param account The user account which is selling the domain
+     */
+    needsToApproveZAuctionToTransferNfts(
+      domainId: string,
+      account: string,
+      signer: ethers.Signer,
+      bid: Bid
+    ): Promise<boolean>;
+
+    /**
+     * Approves zAuction to transfer NFT's on behalf of the user.
+     * Must be done before a bid can be accepted.
+     * @param domainId The domain Id that is going to be sold
+     * @param signer The user account which is selling the domain (connected wallet)
+     */
+    approveZAuctionToTransferNfts(
+      domainId: string,
+      signer: ethers.Signer,
+      bid: Bid
     ): Promise<ethers.ContractTransaction>;
 
     /**
@@ -251,28 +279,6 @@ export interface Instance {
      * @param domainId The id of the domain
      */
     listBids(domainId: string): Promise<any>;
-
-    /**
-     * Checks whether a user has approved zAuction to transfer NFT's on their behalf.
-     * zAuction must be approved before a user can accept a bid for a domain they own.
-     * @param domainId The domain ID that is going to be sold
-     * @param account The user account which is selling the domain
-     */
-    needsToApproveZAuctionToTransferNfts(
-      domainId: string,
-      account: string
-    ): Promise<boolean>;
-
-    /**
-     * Approves zAuction to transfer NFT's on behalf of the user.
-     * Must be done before a bid can be accepted.
-     * @param domainId The domain Id that is going to be sold
-     * @param signer The user account which is selling the domain (connected wallet)
-     */
-    approveZAuctionToTransferNfts(
-      domainId: string,
-      signer: ethers.Signer
-    ): Promise<ethers.ContractTransaction>;
 
     /**
      * Accepts an existing bid to buy a domain.

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,13 @@ export interface Listing {
   price: number;
   holder: string;
 }
+
+export interface ZAuctionInstances {
+  [registrarAddress: string]: zAuction.Instance;
+}
+
 export interface RouteUriToInstance {
-  [key: string]: zAuction.Instance;
+  [key: string]: ZAuctionInstances;
 }
 
 /**
@@ -208,8 +213,6 @@ export interface Instance {
     needsToApproveZAuctionToSpendTokens(
       domainId: string,
       account: string,
-      bid: Bid,
-      signer: ethers.Signer,
       bidAmount: ethers.BigNumber
     ): Promise<boolean>;
 
@@ -220,9 +223,21 @@ export interface Instance {
      */
     approveZAuctionToSpendTokens(
       domainId: string,
-      signer: ethers.Signer,
-      bid: Bid
+      signer: ethers.Signer
     ): Promise<ethers.ContractTransaction>;
+
+    /**
+     * Checks whether a user has approved zAuction to transfer NFT's on their behalf.
+     * zAuction must be approved before a user can accept a bid for a domain they own.
+     * @param domainId The domain ID that is going to be sold
+     * @param account The user account which is selling the domain
+     * @param bid The bid that is being transferred for
+     */
+    needsToApproveZAuctionToTransferNftsByBid(
+      domainId: string,
+      account: string,
+      bid: Bid
+    ): Promise<boolean>;
 
     /**
      * Checks whether a user has approved zAuction to transfer NFT's on their behalf.
@@ -232,10 +247,20 @@ export interface Instance {
      */
     needsToApproveZAuctionToTransferNfts(
       domainId: string,
-      account: string,
-      signer: ethers.Signer,
-      bid: Bid
+      account: string
     ): Promise<boolean>;
+
+    /**
+     * Approves zAuction to transfer NFT's on behalf of the user.
+     * Must be done before a bid can be accepted.
+     * @param domainId The domain Id that is going to be sold
+     * @param signer The user account which is selling the domain (connected wallet)
+     */
+    approveZAuctionToTransferNftsByBid(
+      domainId: string,
+      bid: Bid,
+      signer: ethers.Signer
+    ): Promise<ethers.ContractTransaction>;
 
     /**
      * Approves zAuction to transfer NFT's on behalf of the user.
@@ -245,8 +270,7 @@ export interface Instance {
      */
     approveZAuctionToTransferNfts(
       domainId: string,
-      signer: ethers.Signer,
-      bid: Bid
+      signer: ethers.Signer
     ): Promise<ethers.ContractTransaction>;
 
     /**

--- a/src/utilities/zAuctionRouting.ts
+++ b/src/utilities/zAuctionRouting.ts
@@ -3,19 +3,30 @@ import { zAuctionRoute, RouteUriToInstance } from "../types";
 import { Config } from "..";
 
 type GetDomainNameFromIdFunction = (domainId: string) => Promise<string>;
+type GetDomainContractFromIdFunction = (domainId: string) => Promise<string>;
 
 export const getZAuctionInstanceForDomain = async (
   domainId: string,
   zAuctionRoutes: zAuctionRoute[],
   routeUriToInstance: RouteUriToInstance,
-  getDomainName: GetDomainNameFromIdFunction
+  getDomainName: GetDomainNameFromIdFunction,
+  getDomainContract: GetDomainContractFromIdFunction
 ): Promise<zAuction.Instance> => {
   const domainName = await getDomainName(domainId);
 
   for (const route of zAuctionRoutes) {
     const match = RegExp(`^${route.uriPattern}`).exec(domainName);
     if (match) {
-      const instance = routeUriToInstance[route.uriPattern];
+      const routeInstances = routeUriToInstance[route.uriPattern];
+      const tokenContract = await getDomainContract(domainId);
+      let instance = routeInstances[tokenContract];
+      if (!instance) {
+        instance = zAuction.createInstance({
+          ...route.config,
+          tokenContract, // override token contract with the domains contract
+        });
+        routeInstances[tokenContract] = instance;
+      }
       return instance;
     }
   }
@@ -26,9 +37,7 @@ export const getZAuctionInstanceForDomain = async (
 export const createZAuctionInstances = (config: Config): RouteUriToInstance => {
   const routeUriToInstance: RouteUriToInstance = {};
   for (const route of config.zAuctionRoutes) {
-    routeUriToInstance[route.uriPattern] = zAuction.createInstance(
-      route.config
-    );
+    routeUriToInstance[route.uriPattern] = {};
   }
   return routeUriToInstance;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,10 +908,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@zero-tech/zauction-sdk@0.0.50":
-  version "0.0.50"
-  resolved "https://registry.yarnpkg.com/@zero-tech/zauction-sdk/-/zauction-sdk-0.0.50.tgz#71df4cf49d7d3e9084caa3d048efeaee3d816860"
-  integrity sha512-ZQUqYIWTlj+AOpZZPjCj4XpKiW/H+BNNEJJjLyvUS99MZqFBV4fw/VTwG5EPm6+kwq4za8yexcxadMrZXDxvEw==
+"@zero-tech/zauction-sdk@0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@zero-tech/zauction-sdk/-/zauction-sdk-0.0.51.tgz#2ff870e2e56c32d2293acf90548644ed26eb4cce"
+  integrity sha512-t/7Zcg0j0Oo9qkZ/2q/buE/XpzMWRxOH72TdWKy+Z2qRxcrmeQojVGkclLsMbyjTD7ubni/fBmlR9blM1APjDg==
   dependencies:
     "@apollo/client" "3.4.10"
     "@ethersproject/abi" "5.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,10 +908,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@zero-tech/zauction-sdk@0.0.51":
-  version "0.0.51"
-  resolved "https://registry.yarnpkg.com/@zero-tech/zauction-sdk/-/zauction-sdk-0.0.51.tgz#2ff870e2e56c32d2293acf90548644ed26eb4cce"
-  integrity sha512-t/7Zcg0j0Oo9qkZ/2q/buE/XpzMWRxOH72TdWKy+Z2qRxcrmeQojVGkclLsMbyjTD7ubni/fBmlR9blM1APjDg==
+"@zero-tech/zauction-sdk@0.0.55":
+  version "0.0.55"
+  resolved "https://registry.yarnpkg.com/@zero-tech/zauction-sdk/-/zauction-sdk-0.0.55.tgz#1b36272acffe33a533f1a495b09fa257f6987211"
+  integrity sha512-2x2e5uKYBJeBeDDeUXL6H/O8v59kwznhYSCUwWVelVw3t+zjwLYMEgrRiSmC7NspZgb5712QNFmEo0dO6YiFEQ==
   dependencies:
     "@apollo/client" "3.4.10"
     "@ethersproject/abi" "5.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,10 +908,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@zero-tech/zauction-sdk@0.0.42":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@zero-tech/zauction-sdk/-/zauction-sdk-0.0.42.tgz#a9a74126ba05a643b8e3bc85bd6a67b1cd7f3202"
-  integrity sha512-TM7x3j9cvlcHLaYpq1ZCrTCwgYhUjDr8P+NDpP+7RMEhTLRFNQNGkS+ZlKHsKf6ngxgItaKp5BCI34LYtBiUAg==
+"@zero-tech/zauction-sdk@0.0.50":
+  version "0.0.50"
+  resolved "https://registry.yarnpkg.com/@zero-tech/zauction-sdk/-/zauction-sdk-0.0.50.tgz#71df4cf49d7d3e9084caa3d048efeaee3d816860"
+  integrity sha512-ZQUqYIWTlj+AOpZZPjCj4XpKiW/H+BNNEJJjLyvUS99MZqFBV4fw/VTwG5EPm6+kwq4za8yexcxadMrZXDxvEw==
   dependencies:
     "@apollo/client" "3.4.10"
     "@ethersproject/abi" "5.4.1"


### PR DESCRIPTION
Instead of calling zAuction directly in the dApp, the following can (and should be used) to map domain bids to the proper registrar contracts.

zauction-sdk -> zns-sdk mapping:
getZAuctionSpendAllowance -> needsToApproveZAuctionToSpendTokens 
approveZAuctionToSpendTokens -> approveZAuctionSpendTradeTokensByBid
isZAuctionApprovedToTransferNft -> needsToApproveZAuctionToTransferNfts
approveZAuctionToTransferNfts -> approveZAuctionTransferNftByBid
