### PR TITLE
Adding configuration value for DomainPurchaser

### DIFF
--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -7,6 +7,7 @@ const mainnetRegistrar = "0xc2e9678A71e50E5AEd036e00e9c5caeb1aC5987D";
 const mainnetHub = "0x3F0d0a0051D1E600B3f6B35a07ae7A64eD1A10Ca";
 const mainnetStaking = "0x45b13d8e6579d5C3FeC14bB9998A3640CD4F008D";
 const mainnetBasicController = "0xa05Ae774Da859943B7B859cd2A6aD9F5f1651d6a";
+const mainnetDomainPurchaser = ethers.constants.AddressZero;
 
 export const mainnetConfiguration = (
   provider: ethers.providers.Provider
@@ -27,6 +28,7 @@ export const mainnetConfiguration = (
     registrar: mainnetRegistrar,
     hub: mainnetHub,
     provider: provider,
+    domainPurchaser: mainnetDomainPurchaser
   };
 };
 
@@ -34,6 +36,7 @@ const kovanRegistrar = "0xC613fCc3f81cC2888C5Cccc1620212420FFe4931";
 const kovanHub = ethers.constants.AddressZero;
 const kovanStaking = "0x1E3F8B31b24EC0E938BE45ecF6971584F90A1602";
 const kovanBasicController = "0x2EF34C52138781C901Fe9e50B64d80aA9903f730";
+const kovanDomainPurchaser = ethers.constants.AddressZero;
 
 export const kovanConfiguration = (
   provider: ethers.providers.Provider
@@ -54,6 +57,7 @@ export const kovanConfiguration = (
     registrar: kovanRegistrar,
     hub: kovanHub,
     provider: provider,
+    domainPurchaser: kovanDomainPurchaser
   };
 };
 
@@ -61,7 +65,7 @@ const rinkebyRegistrar = "0xa4F6C921f914ff7972D7C55c15f015419326e0Ca";
 const rinkebyHub = "0x90098737eB7C3e73854daF1Da20dFf90d521929a";
 const rinkebyStaking = "0x7FDd24f30fB8a3E0021e85Fdb737a3483D3C8135";
 const rinkebyBasicController = "0x1188dD1a0F42BA4a117EF1c09D884f5183D40B28";
-
+const rinkebyDomainPurchaser = ethers.constants.AddressZero;
 export const rinkebyConfiguration = (
   provider: ethers.providers.Provider
 ): Config => {
@@ -81,5 +85,6 @@ export const rinkebyConfiguration = (
     registrar: rinkebyRegistrar,
     hub: rinkebyHub,
     provider: provider,
+    domainPurchaser: rinkebyDomainPurchaser
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export interface Config {
   registrar: string;
   /** Address of the zNS Hub */
   hub: string;
+  /** Address of the domain Purchaser*/
+  domainPurchaser: string;
   /** Web3 provider to make web3 calls with */
   provider: ethers.providers.Provider;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface Config {
   registrar: string;
   /** Address of the zNS Hub */
   hub: string;
-  /** Address of the domain Purchaser*/
+  /** Address of the Domain Purchaser*/
   domainPurchaser: string;
   /** Web3 provider to make web3 calls with */
   provider: ethers.providers.Provider;


### PR DESCRIPTION
Adding a configuration value for the DomainPurchaser in all environments.  Right now that contract hasn't been deployed so its defaulted to the zero address.