### PR TITLE
Update zauction sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/sinon": "10.0.2",
     "@typescript-eslint/eslint-plugin": "4.31.0",
     "@typescript-eslint/parser": "4.31.0",
-    "@zero-tech/zauction-sdk": "0.2.6",
+    "@zero-tech/zauction-sdk": "0.2.7",
     "chai": "4.3.4",
     "chai-as-promised": "7.1.1",
     "eslint": "7.32.0",

--- a/src/actions/generateDefaultMetadata.ts
+++ b/src/actions/generateDefaultMetadata.ts
@@ -4,21 +4,23 @@ import { getLogger } from "../utilities";
 
 const logger = getLogger("actions:generateDefaultMetadata");
 const DEFAULT_IMAGE = "ipfs://QmP3uXEBuuJQwWWwLAxGqBAa2sviKCnexyuWKyk6i8NnLJ";
-const DEFAULT_IMAGE_FULL = "ipfs://QmS6DZzG6pTdWszubmDXzJ7vcEWsPNMGJZuviDaCMc7beB";
-const DEFAULT_ANIMATION_URL = "ipfs://QmY11GVZDjFjqYKDYur4Z64QCyXGSbgovHXEZzDPYjFNxr";
+const DEFAULT_IMAGE_FULL =
+  "ipfs://QmS6DZzG6pTdWszubmDXzJ7vcEWsPNMGJZuviDaCMc7beB";
+const DEFAULT_ANIMATION_URL =
+  "ipfs://QmY11GVZDjFjqYKDYur4Z64QCyXGSbgovHXEZzDPYjFNxr";
 export const generateDefaultMetadata = async (
   apiClient: znsApiClient,
   name: string
 ): Promise<string> => {
-    const domainMetaData: DomainMetadata = {
-        name: `0://${name}`,
-        description: `0://${name} - A Zero Name Service (zNS) Root Domain on the Ethereum Blockchain`,
-        image: DEFAULT_IMAGE,
-        animation_url: DEFAULT_ANIMATION_URL,
-        image_full: DEFAULT_IMAGE_FULL
-    }
-    logger.trace(`Generating default metadata for: ${name}`);
-    const metadataUri = await apiClient.uploadMetadata(domainMetaData);
-    logger.trace(`IPFS Uri generated: ${metadataUri}`);
-    return metadataUri;
+  const domainMetaData: DomainMetadata = {
+    name: `0://${name}`,
+    description: `0://${name} - A Zero Name Service (zNS) Root Domain on the Ethereum Blockchain`,
+    image: DEFAULT_IMAGE,
+    animation_url: DEFAULT_ANIMATION_URL,
+    image_full: DEFAULT_IMAGE_FULL,
+  };
+  logger.trace(`Generating default metadata for: ${name}`);
+  const metadataUri = await apiClient.uploadMetadata(domainMetaData);
+  logger.trace(`IPFS Uri generated: ${metadataUri}`);
+  return metadataUri;
 };

--- a/src/actions/getPriceOfNetworkDomain.ts
+++ b/src/actions/getPriceOfNetworkDomain.ts
@@ -8,9 +8,8 @@ export const getPriceOfNetworkDomain = async (
   name: string,
   domainPurchaser: DomainPurchaser
 ): Promise<string> => {
-    logger.trace(`Get price of network domain for: ${name}`);
-    const price = await domainPurchaser
-      .getDomainPrice(0, name);
-    const formattedPrice = ethers.utils.formatEther(price);
-    return formattedPrice;
+  logger.trace(`Get price of network domain for: ${name}`);
+  const price = await domainPurchaser.getDomainPrice(0, name);
+  const formattedPrice = ethers.utils.formatEther(price);
+  return formattedPrice;
 };

--- a/src/actions/minting/isNetworkDomainAvailable.ts
+++ b/src/actions/minting/isNetworkDomainAvailable.ts
@@ -19,7 +19,7 @@ export const isNetworkDomainAvailable = async (
     return false;
   }
   //Check domain availability
-  let id = domainNameToId(name);
+  const id = domainNameToId(name);
   const available = !(await hub.domainExists(id));
   return available;
 };

--- a/src/actions/setDomainMetadata.ts
+++ b/src/actions/setDomainMetadata.ts
@@ -15,9 +15,7 @@ export const setDomainMetadata = async (
   signer: ethers.Signer,
   hub: ZNSHub
 ): Promise<ethers.ContractTransaction> => {
-  logger.trace(
-    `Calling to set domain metadata for domain ${domainId}`
-  );
+  logger.trace(`Calling to set domain metadata for domain ${domainId}`);
   const isLocked = true;
   const signerAddress = await signer.getAddress();
   const registrar = await getRegistrarForDomain(hub, domainId);

--- a/src/actions/setDomainMetadataUri.ts
+++ b/src/actions/setDomainMetadataUri.ts
@@ -12,9 +12,7 @@ export const setDomainMetadataUri = async (
   signer: ethers.Signer,
   hub: ZNSHub
 ): Promise<ethers.ContractTransaction> => {
-  logger.trace(
-    `Calling to set domain metadata URI for domain ${domainId}`
-  );
+  logger.trace(`Calling to set domain metadata URI for domain ${domainId}`);
   const isLocked = true;
   const signerAddress = await signer.getAddress();
   const registrar = await getRegistrarForDomain(hub, domainId);

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,9 +1,9 @@
-import { Map } from "../types"
+import { Map } from "../types";
 export interface CoinGeckoPrice {
   usd: number;
 }
 
-export interface CoinGeckoResponse extends Map<CoinGeckoPrice>{}
+export type CoinGeckoResponse = Map<CoinGeckoPrice>;
 
 export interface CoinGeckoRequestOptions {
   ids?: string;

--- a/src/actions/zauction/getZAuctionSpendAllowance.ts
+++ b/src/actions/zauction/getZAuctionSpendAllowance.ts
@@ -48,7 +48,9 @@ export const getZauctionSpendAllowance = async (
   }
 
   if (params.tokenId) {
-    logger.trace(`Getting allowance for ${account} by tokenId ${params.tokenId}`);
+    logger.trace(
+      `Getting allowance for ${account} by tokenId ${params.tokenId}`
+    );
     allowance = await getAllowance<string>(
       sdk.getZAuctionSpendAllowanceByDomain,
       account,

--- a/src/api/dataStoreApi/actions/getSubdomainsById.ts
+++ b/src/api/dataStoreApi/actions/getSubdomainsById.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
 
 export const getSubdomainsById = async (
   apiUri: string,
-  tokenId: string,
+  tokenId: string
 ): Promise<Domain[]> => {
   let response: Maybe<DomainCollection>;
   const body: RequestBody = {

--- a/src/api/dataStoreApi/client.ts
+++ b/src/api/dataStoreApi/client.ts
@@ -14,7 +14,10 @@ export const createDataStoreApiClient = (
   const apiClient: DataStoreApiClient = {
     getSubdomainsById: async (tokenId: string) => {
       logger.debug("Calling to getSubdomainsById");
-      let domains: Domain[] = await actions.getSubdomainsById(apiUri, tokenId);
+      const domains: Domain[] = await actions.getSubdomainsById(
+        apiUri,
+        tokenId
+      );
 
       return domains;
     },

--- a/src/api/dataStoreApi/types.ts
+++ b/src/api/dataStoreApi/types.ts
@@ -50,11 +50,11 @@ export interface DomainCollection {
 }
 
 interface RequestBodyOptionsSort {
-  [domainProperty: string]: SortOrder
+  [domainProperty: string]: SortOrder;
 }
 
 interface RequestBodyOptionsProjection {
-  [domainProperty: string]: OptionsValue
+  [domainProperty: string]: OptionsValue;
 }
 
 interface RequestBodyOptions {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,5 @@
 export { createZnsApiClient, znsApiClient } from "./znsApi/client";
-export { createDataStoreApiClient, DataStoreApiClient as DataStoreApiClient } from "./dataStoreApi/client";
+export {
+  createDataStoreApiClient,
+  DataStoreApiClient as DataStoreApiClient,
+} from "./dataStoreApi/client";

--- a/src/api/znsApi/index.ts
+++ b/src/api/znsApi/index.ts
@@ -1,1 +1,1 @@
-export * from "./client"
+export * from "./client";

--- a/src/api/znsApi/types.ts
+++ b/src/api/znsApi/types.ts
@@ -11,10 +11,10 @@ export interface ContentModeration {
 }
 
 export interface ContentClassification {
-  ReviewRecommended: boolean,
-  SexuallyExplicitRating: ContentCategoryScore,
-  SexuallySuggestiveRating: ContentCategoryScore,
-  OffensiveRating: ContentCategoryScore
+  ReviewRecommended: boolean;
+  SexuallyExplicitRating: ContentCategoryScore;
+  SexuallySuggestiveRating: ContentCategoryScore;
+  OffensiveRating: ContentCategoryScore;
 }
 
 export interface ContentCategoryScore {

--- a/src/configuration/zAuction.ts
+++ b/src/configuration/zAuction.ts
@@ -12,9 +12,7 @@ export interface zAuctionConfig {
   znsHubAddress?: string;
 }
 
-export const configuration = (
-  params: zAuctionConfig
-): zAuction.Config => {
+export const configuration = (params: zAuctionConfig): zAuction.Config => {
   let defaultApiUri;
   let defaultSubgraphUri;
   let defaultZAuctionAddress;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   getBidEventsFunction,
   getSaleEventsFunction,
   getBuyNowSaleEventsFunction,
+  BuyNowListing,
 } from "./zAuction";
 import {
   Config,
@@ -80,7 +81,7 @@ export const createInstance = (config: Config): Instance => {
     getDomainsByOwner: subgraphClient.getDomainsByOwner,
     getSubdomainsById: async (
       domainId: string,
-      useDataStoreAPI: boolean = true
+      useDataStoreAPI = true
     ): Promise<Domain[]> => {
       let domains: Domain[];
       if (useDataStoreAPI) {
@@ -473,11 +474,12 @@ export const createInstance = (config: Config): Instance => {
         const tx = await zAuctionSdkInstance.buyNow(params, signer);
         return tx;
       },
-      getBuyNowPrice: async (tokenId: string): Promise<string> => {
-        const buyNowListing = await zAuctionSdkInstance.getBuyNowListing(
-          tokenId
-        );
-        return ethers.utils.formatEther(buyNowListing.price);
+      getBuyNowListing: async (
+        tokenId: string
+      ): Promise<Maybe<BuyNowListing>> => {
+        const buyNowListing: Maybe<BuyNowListing> =
+          await zAuctionSdkInstance.getBuyNowListing(tokenId);
+        return buyNowListing;
       },
       setBuyNowPrice: async (
         params: zAuction.BuyNowParams,

--- a/src/subgraph/dex/actions/getTokenInfo.ts
+++ b/src/subgraph/dex/actions/getTokenInfo.ts
@@ -1,7 +1,12 @@
 import { ApolloClient, DocumentNode } from "@apollo/client/core";
 import { Maybe, TokenInfo } from "../../../types";
 import * as queries from "../queries";
-import { UniswapTokenDto, QueryOptions, TokenCollectionBase, TokenDto } from "../types";
+import {
+  UniswapTokenDto,
+  QueryOptions,
+  TokenCollectionBase,
+  TokenDto,
+} from "../types";
 import { performQuery } from "../../helpers";
 import { getLogger } from "../../../utilities";
 
@@ -26,6 +31,6 @@ export const getTokenInfo = async <TCacheShape, T extends TokenDto>(
 
   const token = queryResult.data.tokens[0];
 
-  logger.trace(`Found token ${token.symbol} at address ${tokenAddress}`)
+  logger.trace(`Found token ${token.symbol} at address ${tokenAddress}`);
   return token;
 };

--- a/src/subgraph/dex/actions/index.ts
+++ b/src/subgraph/dex/actions/index.ts
@@ -1,1 +1,1 @@
-export * from "./getTokenInfo"
+export * from "./getTokenInfo";

--- a/src/subgraph/dex/types.ts
+++ b/src/subgraph/dex/types.ts
@@ -18,4 +18,4 @@ export interface TokenCollectionBase<T> {
   tokens: T[];
 }
 
-export interface QueryOptions extends Map<string> {}
+export type QueryOptions = Map<string>;

--- a/src/subgraph/zns/actions/getMostRecentSubdomainsById.ts
+++ b/src/subgraph/zns/actions/getMostRecentSubdomainsById.ts
@@ -42,7 +42,7 @@ export const getMostRecentSubdomainsById = async <T>(
      * So if we get that many there's probably more domains we need
      * to fetch. If we got back less, we can stop querying
      */
-     yetUnreceived -= queriedDomains.length;
+    yetUnreceived -= queriedDomains.length;
     if (queriedDomains.length < count || yetUnreceived <= 0) {
       break;
     }

--- a/src/subgraph/zns/client.ts
+++ b/src/subgraph/zns/client.ts
@@ -1,8 +1,13 @@
-import { Domain, DomainMintEvent, DomainTransferEvent, Maybe } from "../../types";
+import {
+  Domain,
+  DomainMintEvent,
+  DomainTransferEvent,
+  Maybe,
+} from "../../types";
 import { getLogger } from "../../utilities";
 
 import * as actions from "./actions";
-import { createApolloClient } from "../helpers"
+import { createApolloClient } from "../helpers";
 
 const logger = getLogger().withTag("subgraph:client");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 import * as zAuction from "./zAuction";
 import { ContractTransaction, ethers } from "ethers";
-import { Bid } from "./zAuction";
+import { Bid, BuyNowListing } from "./zAuction";
 
-export interface DexSubgraphUris extends Map<string> {}
+export type DexSubgraphUris = Map<string>;
 
 /**
  * Configuration for a zNS sdk instance
@@ -578,10 +578,10 @@ export interface Instance {
     ): Promise<ethers.ContractTransaction>;
 
     /**
-     * Gets the buy now price of a domain
-     * @param domainId The token to get the price for
+     * Gets the buy now listing for a domain, if one exists
+     * @param tokenId The domain to get the price for
      */
-    getBuyNowPrice(domainId: string): Promise<string>;
+    getBuyNowListing(tokenId: string): Promise<Maybe<BuyNowListing>>;
 
     /**
      * Sets the buy now price for a domain

--- a/src/utilities/logging.ts
+++ b/src/utilities/logging.ts
@@ -1,7 +1,7 @@
-import { Consola, LogLevel }  from "consola";
+import { Consola, LogLevel } from "consola";
 
 // Default level is Info
-const logger = new Consola({level: 3});
+const logger = new Consola({ level: 3 });
 
 export const getLogger = (tag?: string): Consola => {
   if (tag) {

--- a/src/zAuction/index.ts
+++ b/src/zAuction/index.ts
@@ -51,8 +51,8 @@ export const getSaleEventsFunction = (
         amount: e.saleAmount,
         paymentToken: e.paymentToken,
         domainNetworkId: e.topLevelDomainId,
-      }
-      return saleEvent
+      };
+      return saleEvent;
     });
 
     return saleEvents;

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -8,7 +8,7 @@ import * as zNSSDK from "../src/index";
 import * as subgraph from "../src/subgraph";
 import * as api from "../src/api";
 import * as actions from "../src/actions";
-import { Config, Domain, IPFSGatewayUri } from "../src/types";
+import { Config, Domain, IPFSGatewayUri, Maybe } from "../src/types";
 import { Registrar } from "../src/contracts/types";
 import { getHubContract, getRegistrar } from "../src/contracts";
 
@@ -28,12 +28,12 @@ const enum ChainId {
 }
 
 describe("Test Custom SDK Logic", () => {
-  const provider = new ethers.providers.JsonRpcProvider(
+  const provider = new ethers.providers.StaticJsonRpcProvider(
     process.env["INFURA_URL"],
     ChainId.rinkeby
   );
 
-  const pk = process.env["TESTNET_PRIVATE_KEY_MAIN"];
+  const pk = process.env.PRIVATE_KEY_ASTRO;
   if (!pk) throw Error("No private key");
   const signer = new ethers.Wallet(pk, provider);
 
@@ -109,7 +109,7 @@ describe("Test Custom SDK Logic", () => {
       const metadata = await actions.getDomainMetadata(
         wilderPancakesDomain,
         hub,
-        IPFSGatewayUri.fleek
+        IPFSGatewayUri.ipfs
       );
       expect(metadata);
     });
@@ -185,9 +185,12 @@ describe("Test Custom SDK Logic", () => {
   describe("(get|set)buyNowPrice", () => {
     it("runs as expected", async () => {
       // Set to a new value every time it's run, loop is same as current price
-      let listing: BuyNowListing = await zAuctionSdkInstance.getBuyNowListing(
+      let listing: Maybe<BuyNowListing> = await zAuctionSdkInstance.getBuyNowListing(
         wilderPancakesDomain
       );
+      if (!listing) {
+        throw Error(`No listing found for domain ${wilderPancakesDomain}, it may not be set by the owner or the owner has changed`)
+      }
       let newBuyNowPrice = ethers.utils.parseEther(
         Math.round(Math.random() * 100).toString()
       );

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -44,7 +44,7 @@ describe("SDK test", () => {
   const domainFromBrett =
     "0xada136a490b49f140280941197b1c56cdc9668ec9c8b515c8f00d116b9942c09";
 
-  const pk = process.env.TESTNET_PRIVATE_KEY_ASTRO;
+  const pk = process.env.PRIVATE_KEY_ASTRO;
   if (!pk) throw Error("no private key");
 
   const provider = new ethers.providers.JsonRpcProvider(

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,10 +920,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@zero-tech/zauction-sdk@0.2.6":
-  version "0.2.6"
-  resolved "https://registry.npmjs.org/@zero-tech/zauction-sdk/-/zauction-sdk-0.2.6.tgz"
-  integrity sha512-cJBs3Tf7H7TSrigSbGaPUto4vpPDbbZ94wsBKp3ocfmfTe3oci5p7DfKL267gmvn6gEucpbxgxrg3zHNrGXbgA==
+"@zero-tech/zauction-sdk@0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@zero-tech/zauction-sdk/-/zauction-sdk-0.2.7.tgz#5cfd75efbf7a0330cb978fbcee27a4d0834205a7"
+  integrity sha512-2FO63wfVMgbZtwl42vVSC65OSBul5IwN9G+jLJkUIu7tV/GOhVE9TDhk7rmRogtwxH/YS1mMqax/YdKRMhZvyg==
   dependencies:
     "@apollo/client" "3.4.10"
     "@ethersproject/abi" "5.4.1"


### PR DESCRIPTION
Also update test to match change with returning `buyNowListing` not just the price.

This also includes a bunch of linter auto fixes, but the logical code change is in `src/index/getBuyNowListing` which has been upgraded in `package.json > zauction-sdk: 0.2.7` to now return undefined if there is no listing present, rather than throwing an error