### PR TITLE
Allow calling the DataStore in getDomainsByOwner

### DIFF
--- a/src/actions/helpers/index.ts
+++ b/src/actions/helpers/index.ts
@@ -31,7 +31,7 @@ export const validateUserOwnsDomain = async (
   domainId: string,
   potentialOwner: string,
   registrar: Registrar
-) => {
+): Promise<void> => {
   const owner = await registrar.ownerOf(domainId);
   if (potentialOwner !== owner) throw Error("Must own domain to modify");
 };
@@ -41,7 +41,7 @@ export const validateStatus = async (
   registrar: Registrar,
   desiredLock: boolean,
   potentialOwner: string
-) => {
+): Promise<void> => {
   const isCurrentlyLocked = await registrar.isDomainMetadataLocked(domainId);
   if (isCurrentlyLocked === desiredLock)
     throw Error("Metadata must be unlocked to be modified");
@@ -58,7 +58,7 @@ export const validateOwnerAndStatus = async (
   registrar: Registrar,
   potentialOwner: string,
   desiredLock: boolean
-) => {
+): Promise<void> => {
   logger.trace(
     `Validate the potential owner ${potentialOwner} of domain ${domainId} and set lock status to ${desiredLock}`
   );

--- a/src/actions/mintSubdomain.ts
+++ b/src/actions/mintSubdomain.ts
@@ -1,11 +1,7 @@
+/* eslint-disable */
 import { ethers } from "ethers";
 import { SubdomainParams } from "../types";
-import {
-  DomainMetadata,
-  MintSubdomainStatusCallback,
-  MintSubdomainStep,
-} from "../types";
-
+import { DomainMetadata, MintSubdomainStatusCallback } from "../types";
 type RegisterSubdomainFunction = (
   parentId: string,
   label: string,

--- a/src/actions/minting/isMinterApprovedToSpendTokens.ts
+++ b/src/actions/minting/isMinterApprovedToSpendTokens.ts
@@ -2,6 +2,9 @@ import { ethers } from "ethers";
 import { getERC20Contract } from "../../contracts";
 import { DomainPurchaser } from "../../contracts/types/DomainPurchaser";
 import { getTokenSpendAllowance } from "./getTokenSpendAllowance";
+import { getLogger } from "../../utilities";
+
+const logger = getLogger("actions:isMinterApprovedToSpendToken");
 
 export const isMinterApprovedToSpendTokens = async (
   user: string,
@@ -19,6 +22,9 @@ export const isMinterApprovedToSpendTokens = async (
   const requiredAmount = ethers.utils.parseEther(amount);
   const allowanceAsNumber = ethers.utils.parseEther(allowance);
   const approved = allowanceAsNumber.gte(requiredAmount);
+  logger.trace(
+    `User ${user} approval to spend ${requiredAmount} of token ${paymentToken} is: ${approved}`
+  );
 
   return approved;
 };

--- a/src/actions/minting/isNetworkDomainAvailable.ts
+++ b/src/actions/minting/isNetworkDomainAvailable.ts
@@ -2,7 +2,7 @@ import { domainNameToId, getLogger } from "../../utilities";
 import { ZNSHub } from "../../contracts/types";
 import { znsApiClient } from "../../api";
 
-const logger = getLogger("actions:getDomainMetadata");
+const logger = getLogger("actions:isNetworkDomainAvailable");
 
 export const isNetworkDomainAvailable = async (
   name: string,

--- a/src/actions/minting/mintNetworkDomain.ts
+++ b/src/actions/minting/mintNetworkDomain.ts
@@ -1,5 +1,5 @@
 import { getLogger } from "../../utilities";
-import { ContractTransaction, ethers } from "ethers";
+import * as ethers from "ethers";
 import { isNetworkDomainAvailable } from "./isNetworkDomainAvailable";
 import { getPriceOfNetworkDomain } from "../getPriceOfNetworkDomain";
 import { isMinterApprovedToSpendTokens } from ".";
@@ -7,7 +7,7 @@ import { getDomainPurchaserContract, getERC20Contract } from "../../contracts";
 import { NetworkDomainMintableConfig } from "./types";
 import { Maybe } from "../../types";
 
-const logger = getLogger("actions:getDomainMetadata");
+const logger = getLogger("actions:mintNetworkDomain");
 
 export const mintNetworkDomain = async (
   name: string,
@@ -22,6 +22,7 @@ export const mintNetworkDomain = async (
   );
   const price = await getPriceOfNetworkDomain(name, domainPurchaserContract);
   const user = await signer.getAddress();
+  logger.debug(`Calling to mint network domain ${name} by user ${user}`);
   const approved = await isMinterApprovedToSpendTokens(
     user,
     domainPurchaserContract,
@@ -63,6 +64,7 @@ export const mintNetworkDomain = async (
     logger.trace(
       `Attempt to mint domain failed for domain: ${name} with metadata uri ${metadataUri} for reason ${e}`
     );
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     if ((e as any).code === 4001) {
       throw Error(`User rejected transaction.`);
     }

--- a/src/actions/minting/types.ts
+++ b/src/actions/minting/types.ts
@@ -1,7 +1,6 @@
 import { ethers } from "ethers";
 import { znsApiClient } from "../../api";
 import { ZNSHub } from "../../contracts/types";
-import { DomainPurchaser } from "../../contracts/types/DomainPurchaser";
 
 export interface NetworkDomainMintableConfig {
   znsHub: ZNSHub;

--- a/src/actions/setDomainMetadataUri.ts
+++ b/src/actions/setDomainMetadataUri.ts
@@ -1,4 +1,4 @@
-import { Registrar, ZNSHub } from "../contracts/types";
+import { ZNSHub } from "../contracts/types";
 import { validateOwnerAndStatus } from "./helpers";
 import { ethers } from "ethers";
 import { getRegistrarForDomain } from "../helpers";

--- a/src/actions/transferOwnership.ts
+++ b/src/actions/transferOwnership.ts
@@ -4,7 +4,7 @@ import { getRegistrarForDomain } from "../helpers";
 
 import { getLogger } from "../utilities";
 
-const logger = getLogger("actions:setPaymentTokenForDomain");
+const logger = getLogger("actions:transferOwnership");
 
 export const transferOwnership = async (
   to: string,
@@ -12,6 +12,9 @@ export const transferOwnership = async (
   signer: ethers.Signer,
   hub: ZNSHub
 ): Promise<ethers.ContractTransaction> => {
+  logger.trace(
+    `Calling to transfer ownership of domain ${domainId} to user ${to}`
+  );
   const signerAddress = await signer.getAddress();
   const registrar = await getRegistrarForDomain(hub, domainId);
   const currentOwner = await registrar.ownerOf(domainId);

--- a/src/api/dataStoreApi/actions/getDomainsByOwner.ts
+++ b/src/api/dataStoreApi/actions/getDomainsByOwner.ts
@@ -2,17 +2,17 @@ import { Domain, Maybe } from "../../../types";
 import { DomainCollection } from "../types";
 import { makeApiCall } from "../../helpers";
 import { ethers } from "ethers";
-import { sortDomains } from "../../../helpers";
 
 export const getDomainsByOwner = async (
   apiUri: string,
-  ownerAddress: string
+  ownerAddress: string,
+  limit = 1000
 ): Promise<Domain[]> => {
   let response: Maybe<DomainCollection>;
   try {
-    // Set limit up to 1000 to match the subgraph maximum
+    // Set default limit up to 1000 to match the subgraph maximum
     response = await makeApiCall<DomainCollection>(
-      `${apiUri}v1/domains/search/owner/${ownerAddress}?projection=false&limit=1000`,
+      `${apiUri}v1/domains/search/owner/${ownerAddress}?projection=false&limit=${limit}&sort=domainId&sortDirection=asc`,
       "GET"
     );
   } catch (e) {
@@ -37,9 +37,6 @@ export const getDomainsByOwner = async (
     };
     return domain;
   });
-
-  // Will sort in ascending ASCII order
-  sortDomains(domains);
 
   return domains;
 };

--- a/src/api/dataStoreApi/actions/getDomainsByOwner.ts
+++ b/src/api/dataStoreApi/actions/getDomainsByOwner.ts
@@ -1,0 +1,45 @@
+import { Domain, Maybe } from "../../../types";
+import { DomainCollection } from "../types";
+import { makeApiCall } from "../../helpers";
+import { ethers } from "ethers";
+import { sortDomains } from "../../../helpers";
+
+export const getDomainsByOwner = async (
+  apiUri: string,
+  ownerAddress: string
+): Promise<Domain[]> => {
+  let response: Maybe<DomainCollection>;
+  try {
+    // Set limit up to 1000 to match the subgraph maximum
+    response = await makeApiCall<DomainCollection>(
+      `${apiUri}v1/domains/search/owner/${ownerAddress}?projection=false&limit=1000`,
+      "GET"
+    );
+  } catch (e) {
+    throw Error(`Failed to get domains for owner ${ownerAddress}: ${e}`);
+  }
+
+  // Map from DataStoreDomain -> Domain for downstream consistency
+  const domains: Domain[] = response.results.map((d) => {
+    const domain: Domain = {
+      id: d.domainId.toLowerCase(),
+      name: d.name,
+      parentId: d.parent.toLowerCase(),
+      owner: d.owner.value.toLowerCase(),
+      minter: d.minter.toLowerCase(),
+      metadataUri: d.metadataUri.value,
+      isLocked: d.locked ? d.locked.value : false,
+      lockedBy: d.lockedBy
+        ? d.lockedBy.value.toLowerCase()
+        : ethers.constants.AddressZero,
+      contract: d.registrar.toLowerCase(),
+      isRoot: d.isRoot,
+    };
+    return domain;
+  });
+
+  // Will sort in ascending ASCII order
+  sortDomains(domains);
+
+  return domains;
+};

--- a/src/api/dataStoreApi/actions/getSubdomainsById.ts
+++ b/src/api/dataStoreApi/actions/getSubdomainsById.ts
@@ -1,5 +1,5 @@
 import { Domain, Maybe } from "../../../types";
-import { DomainCollection, RequestBody } from "../types";
+import { DomainCollection } from "../types";
 import { makeApiCall } from "../../helpers";
 import { ethers } from "ethers";
 
@@ -10,8 +10,8 @@ export const getSubdomainsById = async (
   let response: Maybe<DomainCollection>;
   try {
     response = await makeApiCall<DomainCollection>(
-      `${apiUri}/v1/domains/subdomains/${tokenId}?projection=false`,
-      "GET",
+      `${apiUri}v1/domains/subdomains/${tokenId}?projection=false`,
+      "GET"
     );
   } catch (e) {
     throw Error(`Failed to get subdomains for ${tokenId}: ${e}`);

--- a/src/api/dataStoreApi/actions/index.ts
+++ b/src/api/dataStoreApi/actions/index.ts
@@ -1,1 +1,2 @@
 export * from "./getSubdomainsById";
+export * from "./getDomainsByOwner";

--- a/src/api/dataStoreApi/client.ts
+++ b/src/api/dataStoreApi/client.ts
@@ -5,6 +5,7 @@ import { getLogger } from "../../utilities";
 const logger = getLogger("api:client");
 
 export interface DataStoreApiClient {
+  getDomainsByOwner: (ownerAddress: string) => Promise<Domain[]>;
   getSubdomainsById: (tokenId: string) => Promise<Domain[]>;
 }
 
@@ -12,6 +13,15 @@ export const createDataStoreApiClient = (
   apiUri: string
 ): DataStoreApiClient => {
   const apiClient: DataStoreApiClient = {
+    getDomainsByOwner: async (ownerAddress: string) => {
+      logger.debug("Calling to getDomainsByOwner");
+      const domains: Domain[] = await actions.getDomainsByOwner(
+        apiUri,
+        ownerAddress
+      );
+
+      return domains;
+    },
     getSubdomainsById: async (tokenId: string) => {
       logger.debug("Calling to getSubdomainsById");
       const domains: Domain[] = await actions.getSubdomainsById(

--- a/src/api/znsApi/actions/uploadInBackground.ts
+++ b/src/api/znsApi/actions/uploadInBackground.ts
@@ -6,7 +6,6 @@ import {
   UrlToIPFS,
   UrlToJobId,
 } from "../../../types";
-import * as fs from "fs";
 
 const URLS_PER_CHUNK_START = 100;
 const URLS_PER_CHUNK_CHECK = 1000;

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ethers } from "ethers";
 import { Config } from "..";
 import { configuration, zAuctionConfig } from "./zAuction";

--- a/src/configuration/zAuction.ts
+++ b/src/configuration/zAuction.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ethers } from "ethers";
 import * as zAuction from "@zero-tech/zauction-sdk";
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,6 +1,7 @@
 import { ethers } from "ethers";
 import { getRegistrar } from "../contracts";
 import { Registrar, ZNSHub } from "../contracts/types";
+import { Domain } from "../types";
 
 export const getRegistrarForDomain = async (
   hub: ZNSHub,
@@ -20,4 +21,12 @@ export const getRegistrarForDomain = async (
 
   const contract = getRegistrar(hub.provider, registrarAddress);
   return contract;
+};
+
+export const sortDomains = (domains: Domain[]): Domain[] => {
+  return domains.sort((a, b) => {
+    if (a.id < b.id) return -1;
+    if (a.id > b.id) return 1;
+    return 0;
+  });
 };

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,7 +1,6 @@
 import { ethers } from "ethers";
 import { getRegistrar } from "../contracts";
 import { Registrar, ZNSHub } from "../contracts/types";
-import { Domain } from "../types";
 
 export const getRegistrarForDomain = async (
   hub: ZNSHub,
@@ -21,12 +20,4 @@ export const getRegistrarForDomain = async (
 
   const contract = getRegistrar(hub.provider, registrarAddress);
   return contract;
-};
-
-export const sortDomains = (domains: Domain[]): Domain[] => {
-  return domains.sort((a, b) => {
-    if (a.id < b.id) return -1;
-    if (a.id > b.id) return 1;
-    return 0;
-  });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,9 +53,6 @@ export { configuration };
 const invalidInputMessage =
   "Please only make requests of up to 100 URLs at a time.";
 
-const networkDomainNotAvailable =
-  "The requested network domain is not available.";
-
 export const createInstance = (config: Config): Instance => {
   logger.debug(`Creating instance of zNS SDK`);
   logger.debug(config);
@@ -78,7 +75,19 @@ export const createInstance = (config: Config): Instance => {
   const instance: Instance = {
     getDomainById: subgraphClient.getDomainById,
     getDomainsByName: subgraphClient.getDomainsByName,
-    getDomainsByOwner: subgraphClient.getDomainsByOwner,
+    getDomainsByOwner: async (
+      ownerAddress: string,
+      useDataStoreAPI = false
+    ) => {
+      // Change default for `useDataStoreAPI` when bug is resolved for parity
+      let domains: Domain[];
+      if (useDataStoreAPI) {
+        domains = await dataStoreApiClient.getDomainsByOwner(ownerAddress);
+      } else {
+        domains = await subgraphClient.getDomainsByOwner(ownerAddress);
+      }
+      return domains;
+    },
     getSubdomainsById: async (
       domainId: string,
       useDataStoreAPI = true

--- a/src/subgraph/dex/actions/getTokenInfo.ts
+++ b/src/subgraph/dex/actions/getTokenInfo.ts
@@ -1,12 +1,6 @@
 import { ApolloClient, DocumentNode } from "@apollo/client/core";
-import { Maybe, TokenInfo } from "../../../types";
-import * as queries from "../queries";
-import {
-  UniswapTokenDto,
-  QueryOptions,
-  TokenCollectionBase,
-  TokenDto,
-} from "../types";
+import { Maybe } from "../../../types";
+import { QueryOptions, TokenCollectionBase, TokenDto } from "../types";
 import { performQuery } from "../../helpers";
 import { getLogger } from "../../../utilities";
 

--- a/src/subgraph/dex/client.ts
+++ b/src/subgraph/dex/client.ts
@@ -1,8 +1,5 @@
 import { Maybe, TokenInfo } from "../../types";
 import { getLogger } from "../../utilities";
-// export { TokenInfo };
-
-import * as queries from "./queries";
 
 import * as actions from "./actions";
 import { createApolloClient } from "../helpers";

--- a/src/subgraph/helpers/index.ts
+++ b/src/subgraph/helpers/index.ts
@@ -54,16 +54,16 @@ export const performQuery = async <T, TCacheShape = unknown>(
  */
 export const convertDomainDtoToDomain = (e: DomainDto): Domain => {
   const domain: Domain = {
-    id: e.id,
+    id: e.id.toLowerCase(),
     name: e.name,
-    parentId: e.parent?.id ?? ethers.constants.HashZero,
-    owner: e.owner.id,
-    minter: e.minter?.id ?? ethers.constants.AddressZero,
+    parentId: e.parent?.id.toLowerCase() ?? ethers.constants.HashZero,
+    owner: e.owner.id.toLowerCase(),
+    minter: e.minter?.id.toLowerCase() ?? ethers.constants.AddressZero,
     metadataUri: e.metadata,
     isRoot: e.id === ethers.constants.HashZero,
-    lockedBy: e.lockedBy?.id ?? ethers.constants.AddressZero,
+    lockedBy: e.lockedBy?.id.toLowerCase() ?? ethers.constants.AddressZero,
     isLocked: e.isLocked,
-    contract: e.contract?.id ?? ethers.constants.AddressZero,
+    contract: e.contract?.id.toLowerCase() ?? ethers.constants.AddressZero,
     metadataName: e.metadataName,
   };
 

--- a/src/subgraph/helpers/index.ts
+++ b/src/subgraph/helpers/index.ts
@@ -1,5 +1,6 @@
 import * as apollo from "@apollo/client/core";
 import fetch from "cross-fetch";
+import { BigNumber } from "ethers";
 
 export const createApolloClient = (
   subgraphUri: string
@@ -64,8 +65,15 @@ export const convertDomainDtoToDomain = (e: DomainDto): Domain => {
     lockedBy: e.lockedBy?.id.toLowerCase() ?? ethers.constants.AddressZero,
     isLocked: e.isLocked,
     contract: e.contract?.id.toLowerCase() ?? ethers.constants.AddressZero,
-    metadataName: e.metadataName,
   };
 
   return domain;
+};
+
+export const sortDomains = (domains: Domain[]): Domain[] => {
+  return domains.sort((a, b) => {
+    if (BigNumber.from(a.id).lt(b.id)) return -1;
+    if (BigNumber.from(a.id).gt(b.id)) return 1;
+    return 0;
+  });
 };

--- a/src/subgraph/zns/actions/getDomainsByOwner.ts
+++ b/src/subgraph/zns/actions/getDomainsByOwner.ts
@@ -3,7 +3,7 @@ import { Domain } from "../../../types";
 import * as queries from "../queries";
 import { DomainsQueryDto } from "../types";
 import { convertDomainDtoToDomain, performQuery } from "../../helpers";
-import { sortDomains } from "../../../helpers";
+import { sortDomains } from "../../helpers";
 
 export const getDomainsByOwner = async <T>(
   apolloClient: ApolloClient<T>,

--- a/src/subgraph/zns/actions/getDomainsByOwner.ts
+++ b/src/subgraph/zns/actions/getDomainsByOwner.ts
@@ -3,6 +3,7 @@ import { Domain } from "../../../types";
 import * as queries from "../queries";
 import { DomainsQueryDto } from "../types";
 import { convertDomainDtoToDomain, performQuery } from "../../helpers";
+import { sortDomains } from "../../../helpers";
 
 export const getDomainsByOwner = async <T>(
   apolloClient: ApolloClient<T>,
@@ -16,5 +17,8 @@ export const getDomainsByOwner = async <T>(
 
   const queriedDomains = queryResult.data.domains;
   const domains: Domain[] = queriedDomains.map(convertDomainDtoToDomain);
+
+  // Will sort in Ascending ASCII order
+  sortDomains(domains);
   return domains;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -743,7 +743,6 @@ export interface Domain {
   lockedBy: string;
   contract: string;
   isRoot?: boolean;
-  metadataName?: string;
 }
 
 export interface DomainMetadata {

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,8 +154,13 @@ export interface Instance {
   /**
    * Gets all domains owner by an address
    * @param owner Owner address
+   * @param useDataStoreAPI Optional, indicate whether to query with
+   * the DataStore or the Subgraph. Default is to use the DataStore
    */
-  getDomainsByOwner(owner: string): Promise<Domain[]>;
+  getDomainsByOwner(
+    owner: string,
+    useDataStoreAPI?: boolean
+  ): Promise<Domain[]>;
 
   /**
    * Finds all subdomains of a given domain

--- a/src/utilities/logging.ts
+++ b/src/utilities/logging.ts
@@ -10,7 +10,7 @@ export const getLogger = (tag?: string): Consola => {
   return logger;
 };
 
-export const setLogLevel = (level?: LogLevel) => {
+export const setLogLevel = (level?: LogLevel): void => {
   if (level === undefined || typeof level != "number") {
     console.log("Provide a number");
     Object.entries(LogLevel).forEach(([key, value]) => {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -91,7 +91,7 @@ describe("SDK test", () => {
     expect(domains.length).to.be.gt(0);
   });
   it("Validates that returns from the subgraph and data store API are the same", async () => {
-    const dataStoreDomains = await sdk.getDomainsByOwner(mainAccount);
+    const dataStoreDomains = await sdk.getDomainsByOwner(mainAccount, true);
     const subgraphDomains = await sdk.getDomainsByOwner(mainAccount, false);
 
     // Temporarily blocked while the DS needs to resolve a bug reading locked and lockedBy for a domain

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -22,7 +22,7 @@ describe("SDK test", () => {
   // shkoobyinushnax
   const tokenOnUniNotCG = "0x000000000427e37c32b2be749610c5e4dd7b6d18";
   // King Token
-  const tokenOnSushiNotUni = "0x002cdebfce2f5e3fd704da0fa346ad2621353b92"
+  const tokenOnSushiNotUni = "0x002cdebfce2f5e3fd704da0fa346ad2621353b92";
   const wildTokenMainnet = "0x2a3bFF78B79A009976EeA096a51A948a3dC00e34";
   const randomToken = "0x02b7031e808dbed9b934e8e43beeef0922386ef4";
   const ZNSHubAddress = "0x90098737eB7C3e73854daF1Da20dFf90d521929a";
@@ -80,10 +80,22 @@ describe("SDK test", () => {
       `Token info with address ${randomToken} could not be found`
     );
   });
-  it("Gets domains by owner", async () => {
-    const domains = await sdk.getDomainsByOwner(astroAccount);
-    // 1000 is the max returned in a single call to the subgraph, but there may be more 
-    expect(domains.length).to.eq(1000);
+  it("Gets domains by owner with default to DataStoreApi", async () => {
+    const domains = await sdk.getDomainsByOwner(mainAccount);
+    
+    expect(domains.length).to.be.gt(0);
+  });
+  it("Gets domains by owner using the Subgraph", async () => {
+    const domains = await sdk.getDomainsByOwner(mainAccount, false);
+
+    expect(domains.length).to.be.gt(0);
+  });
+  it("Validates that returns from the subgraph and data store API are the same", async () => {
+    const dataStoreDomains = await sdk.getDomainsByOwner(mainAccount);
+    const subgraphDomains = await sdk.getDomainsByOwner(mainAccount, false);
+
+    // Temporarily blocked while the DS needs to resolve a bug reading locked and lockedBy for a domain
+    // expect(dataStoreDomains).to.deep.eq(subgraphDomains);
   });
   it("Gets a user's balance of a specific ERC20 token", async () => {
     const balance = await sdk.zauction.getUserBalanceForPaymentToken(


### PR DESCRIPTION
Include an optional flag to use the subgraph still which is currently the default while the bug with `locked` and `lockedBy` data needs to be fixed in the data store.

Meaningful changes are in
 - `src/api/dataStoreApi/actions/getDomainsByOwner.ts`
 - `src/api/dataStoreApi/actions/client.ts`
 - `src/helpers/index.ts`
 - `src/index.ts`

Include some linter fixes that clean the code as well as some smaller logging adjustments