### PR TITLE
Changed Int => BigInt on subgraph queries

### DIFF
--- a/src/subgraph/zns/actions/getAllDomains.ts
+++ b/src/subgraph/zns/actions/getAllDomains.ts
@@ -35,7 +35,8 @@ export const getAllDomains = async <T>(
     for (const domain of queriedDomains) {
       domains.push(convertDomainDtoToDomain(domain));
     }
-    skip = queriedDomains[queriedDomains.length - 1].indexId + 1;
+    console.log(queriedDomains[queriedDomains.length - 1]);
+    skip = parseInt(queriedDomains[queriedDomains.length - 1].indexId) + 1;
   } while (queriedDomains.length >= queryCount);
 
   logger.trace(`Found ${domains.length} domains`);

--- a/src/subgraph/zns/actions/getMostRecentSubdomainsById.ts
+++ b/src/subgraph/zns/actions/getMostRecentSubdomainsById.ts
@@ -43,7 +43,7 @@ export const getMostRecentSubdomainsById = async <T>(
       subDomains.push(convertDomainDtoToDomain(domain));
     }
     yetUnreceived -= queriedDomains.length;
-    skip = queriedDomains[queriedDomains.length - 1].indexId;
+    skip = parseInt(queriedDomains[queriedDomains.length - 1].indexId);
   } while (yetUnreceived > 0 && queriedDomains.length === count);
   logger.trace(`Found ${subDomains.length} recent subdomains of ${domainId}`);
 

--- a/src/subgraph/zns/actions/getSubdomainsById.ts
+++ b/src/subgraph/zns/actions/getSubdomainsById.ts
@@ -37,7 +37,7 @@ export const getSubdomainsById = async <T>(
     for (const domain of queriedDomains) {
       domains.push(convertDomainDtoToDomain(domain));
     }
-    skip = queriedDomains[queriedDomains.length - 1].indexId;
+    skip = parseInt(queriedDomains[queriedDomains.length - 1].indexId);
   } while (queriedDomains.length >= queryCount);
 
   logger.trace(`Found ${domains.length} subdomains of ${domainId}`);

--- a/src/subgraph/zns/queries.ts
+++ b/src/subgraph/zns/queries.ts
@@ -85,7 +85,7 @@ export const getDomainsByMetadataName = gql`
 `;
 
 export const getSubdomainsById = gql`
-  query Subdomains($parent: ID!, $count: Int!, $startIndex: Int!) {
+  query Subdomains($parent: ID!, $count: Int!, $startIndex: BigInt!) {
     domains(
       where: { parent: $parent, indexId_gt: $startIndex }
       first: $count
@@ -171,7 +171,7 @@ export const getDomainMintEvent = gql`
 `;
 
 export const getAllDomains = gql`
-  query Domains($count: Int!, $startIndex: Int!) {
+  query Domains($count: Int!, $startIndex: BigInt!) {
     domains(
       first: $count
       where: { indexId_gte: $startIndex }
@@ -203,7 +203,7 @@ export const getAllDomains = gql`
 `;
 
 export const getPastNDomains = gql`
-  query Domains($count: Int!, $startIndex: Int!) {
+  query Domains($count: Int!, $startIndex: BigInt!) {
     domains(
       first: $count
       orderBy: indexId
@@ -236,7 +236,7 @@ export const getPastNDomains = gql`
 `;
 
 export const getRecentSubdomainsById = gql`
-  query Subdomains($parent: ID!, $count: Int!, $startIndex: Int!) {
+  query Subdomains($parent: ID!, $count: Int!, $startIndex: BigInt!) {
     domains(
       where: { parent: $parent, indexId_gt: $startIndex }
       first: $count

--- a/src/subgraph/zns/types.ts
+++ b/src/subgraph/zns/types.ts
@@ -23,7 +23,7 @@ export interface DomainDto extends DomainIdDto {
   lockedBy?: AccountDto;
   contract?: RegistrarContractDto;
   isLocked: boolean;
-  indexId: number;
+  indexId: string;
   metadataName?: string; // experimental feature
 }
 


### PR DESCRIPTION
Subgraph had a bug where `Int` would not be properly respected if it's nullable on a schema. Changed it to a BigInt which then caused a problem in the sdk.