### PR TITLE
Clean up some leftover mistakes from hotfix

### DIFF
--- a/src/subgraph/zns/actions/getAllDomains.ts
+++ b/src/subgraph/zns/actions/getAllDomains.ts
@@ -35,7 +35,6 @@ export const getAllDomains = async <T>(
     for (const domain of queriedDomains) {
       domains.push(convertDomainDtoToDomain(domain));
     }
-    console.log(queriedDomains[queriedDomains.length - 1]);
     skip = parseInt(queriedDomains[queriedDomains.length - 1].indexId) + 1;
   } while (queriedDomains.length >= queryCount);
 

--- a/src/subgraph/zns/queries.ts
+++ b/src/subgraph/zns/queries.ts
@@ -203,7 +203,7 @@ export const getAllDomains = gql`
 `;
 
 export const getPastNDomains = gql`
-  query Domains($count: Int!, $startIndex: BigInt!) {
+  query Domains($count: Int!, $startIndex: Int!) {
     domains(
       first: $count
       orderBy: indexId


### PR DESCRIPTION
Made a few mistakes; forgot to remove console.log and `skip` does not accept a big int.