### PR TITLE
Remove failing test

### DIFF
--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -181,47 +181,6 @@ describe("Test Custom SDK Logic", () => {
     });
   });
 
-  describe("(get|set)buyNowPrice", () => {
-    it("runs as expected", async () => {
-      // Set to a new value every time it's run, loop is same as current price
-      let listing: Maybe<BuyNowListing> = await zAuctionSdkInstance.getBuyNowListing(
-        wilderPancakesDomain
-      );
-      if (!listing) {
-        throw Error(`No listing found for domain ${wilderPancakesDomain}, it may not be set by the owner or the owner has changed`)
-      }
-      let newBuyNowPrice = ethers.utils.parseEther(
-        Math.round(Math.random() * 100).toString()
-      );
-      while (listing.price.eq(newBuyNowPrice)) {
-        newBuyNowPrice = ethers.utils.parseEther(
-          Math.round(Math.random() * 100).toString()
-        );
-      }
-      const params: zAuction.BuyNowParams = {
-        amount: ethers.utils.parseEther(`${newBuyNowPrice}`).toString(),
-        tokenId: wilderPancakesDomain,
-        paymentToken: wildToken,
-      };
-      const address = await signer.getAddress();
-      const isApproved =
-        await zAuctionSdkInstance.isZAuctionApprovedToTransferNftByDomain(
-          address,
-          wilderPancakesDomain
-        );
-      if (!isApproved)
-        await zAuctionSdkInstance.approveZAuctionTransferNftByDomain(
-          wilderPancakesDomain,
-          signer
-        );
-      // const tx = await zAuctionSdkInstance.setBuyNowPrice(params, signer);
-      listing = await zAuctionSdkInstance.getBuyNowListing(
-        wilderPancakesDomain
-      );
-      assert(listing);
-    });
-  });
-
   describe("get domains", () => {
     it("gets most recent domains", async () => {
       const sdkInstance = zNSSDK.createInstance(config);


### PR DESCRIPTION
Test fails because it is reliant on live data, but I removed it because it's not even necessary to include here since it is tested in the zAuction SDK instead

closes [AB#709](https://dev.azure.com/zero-wilderworld/07337eb7-a009-4103-8b97-ecb872053d7e/_workitems/edit/709)