### PR TITLE
fix data type in queries for subgraph startIndex value

### DIFF
--- a/src/subgraph/zns/queries.ts
+++ b/src/subgraph/zns/queries.ts
@@ -85,7 +85,7 @@ export const getDomainsByMetadataName = gql`
 `;
 
 export const getSubdomainsById = gql`
-  query Subdomains($parent: ID!, $count: Int!, $startIndex: BigInt!) {
+  query Subdomains($parent: ID!, $count: Int!, $startIndex: Int!) {
     domains(
       where: { parent: $parent, indexId_gt: $startIndex }
       first: $count
@@ -171,7 +171,7 @@ export const getDomainMintEvent = gql`
 `;
 
 export const getAllDomains = gql`
-  query Domains($count: Int!, $startIndex: BigInt!) {
+  query Domains($count: Int!, $startIndex: Int!) {
     domains(
       first: $count
       where: { indexId_gte: $startIndex }
@@ -236,7 +236,7 @@ export const getPastNDomains = gql`
 `;
 
 export const getRecentSubdomainsById = gql`
-  query Subdomains($parent: ID!, $count: Int!, $startIndex: BigInt!) {
+  query Subdomains($parent: ID!, $count: Int!, $startIndex: Int!) {
     domains(
       where: { parent: $parent, indexId_gt: $startIndex }
       first: $count

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -88,6 +88,11 @@ describe("Test Custom SDK Logic", () => {
       // }
       // const tx = await sdkInstance.mintSubdomain(params, signer);
     });
+    it ("calls getSubdomainsById through the subgraph", async () => {
+      const sdkInstance = await zNSSDK.createInstance(config);
+      const rootSubdomains = await sdkInstance.getSubdomainsById(ethers.constants.HashZero, false);
+      expect(rootSubdomains).to.not.be.empty;
+    });
     it("gets all domains", async () => {
       const sdkInstance = await zNSSDK.createInstance(config);
       const allDomains = await sdkInstance.getAllDomains();


### PR DESCRIPTION
Closes AB#1130

Change the `startIndex` data type in subgraph queries from `BigInt` to `Int`