### PR TITLE
Sort buyNow by recency

### DIFF
--- a/src/api/dataStoreApi/client.ts
+++ b/src/api/dataStoreApi/client.ts
@@ -84,7 +84,7 @@ export const createDataStoreApiClient = (
       sort?: DomainSortOptions
     ) => {
       logger.debug("Calling to getSubdomainsByIdDeep");
-      const domains: Domain[] = await actions.getSubdomainsById(
+      const domains: Domain[] = await actions.getSubdomainsByIdDeep(
         apiUri,
         tokenId,
         limit,

--- a/src/api/dataStoreApi/helpers/desiredSortToQueryParams.ts
+++ b/src/api/dataStoreApi/helpers/desiredSortToQueryParams.ts
@@ -12,7 +12,8 @@ export const domainSortingOptionsReflection = {
   created: undefined,
   registrar: undefined,
   isValid: false,
-  buyNow: undefined,
+  "buyNow.price": undefined,
+  "buyNow.time": undefined,
 };
 
 export function desiredSortToQueryParams(sort: DomainSortOptions) {

--- a/src/api/dataStoreApi/types.ts
+++ b/src/api/dataStoreApi/types.ts
@@ -97,5 +97,6 @@ export type DomainSortOptions = {
   royaltyAmount?: "asc" | "desc";
   registrar?: "asc" | "desc";
   isValid?: "asc" | "desc";
-  buyNow?: "asc" | "desc";
+  "buyNow.price"?: "asc" | "desc";
+  "buyNow.time"?: "asc" | "desc";
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -672,7 +672,7 @@ export const createInstance = (config: Config): Instance => {
           tokenAddress
         );
 
-        let approvalAmount = amount ?? ethers.constants.MaxUint256;
+        const approvalAmount = amount ?? ethers.constants.MaxUint256;
 
         const tx = await paymentToken
           .connect(signer)


### PR DESCRIPTION
UserStory [#1185](https://dev.azure.com/zero-wilderworld/Core%20Protocol%20Team/_workitems/edit/1185).

* fixed wrong function calling `getSubdomainsByIdDeep`
* added test script for sorting buyNow by price or time separately